### PR TITLE
BAU - Disable Dockerfile digest pinning

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,6 +20,10 @@
       "groupName": "Pre-commit updates",
       "matchPackageNames": ["!astral-sh/ruff-pre-commit"],
       "matchManagers": ["pre-commit"]
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "pinDigests": false
     }
   ],
   "rangeStrategy": "pin"


### PR DESCRIPTION
This change is to prevent Renovate from pinning Dockerfile source images to specific digests. Dockerfiles are not used in production and as such PRs to update digests in Dockerfiles can be considered noise.

The current behaviour is _to_ pin digests, see [this PR](https://github.com/communitiesuk/funding-service-design-post-award-data-store/pull/821/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557) for example.

This is because in the `default.json` config, we extend [config:best-practices](https://docs.renovatebot.com/presets-config/#configbest-practices), which includes the configuration option [docker:pinDigests](https://docs.renovatebot.com/configuration-options/#pindigests), which "add(s) digests to Dockerfile source images".