### PR TITLE
BAU Require explicit approval for major frontend version

### DIFF
--- a/default.json
+++ b/default.json
@@ -82,7 +82,10 @@
       "prBodyNotes": [
         "## Notice for developers\n\nPython's `govuk-frontend-jinja` package and the JavaScript package `govuk-frontend` need to be bumped together and kept aligned according to this [Compatibility table](https://github.com/LandRegistry/govuk-frontend-jinja?tab=readme-ov-file#compatibility). You must manually work out what versions we should upgrade to, and should not rely on Renovate to get it correct (this PR exists as a reminder to keep these dependencies up-to-date, but unlike other PRs, manual work is required.",
         "### Design/product review may be required\n\nMinor and major version bumps of GOV.UK Frontend should only be accepted in collaboration with design and a detailed review of how changes will affect the service."
-      ]
+      ],
+      "major": {
+        "dependencyDashboardApproval": true
+      }
     }
   ],
   "rangeStrategy": "pin"


### PR DESCRIPTION
We'll often have to do extra design + dev work to upgrade to a major govuk frontend version so instruct renovate to not raise the PR unless we've got the time to prioritise it.

```
npx --yes --package renovate -- renovate-config-validator default.json
> INFO: Validating default.json as global config
> INFO: Config validated successfully
```